### PR TITLE
Add Gradio transcription demo

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -1,0 +1,46 @@
+import os
+import shutil
+import tempfile
+
+import gradio as gr
+from moviepy.editor import VideoFileClip
+from faster_whisper import WhisperModel
+
+MODEL_SIZE = os.getenv("MODEL_SIZE", "small")
+model = WhisperModel(MODEL_SIZE)
+
+
+def transcribe(file_obj):
+    file_path = getattr(file_obj, "name", file_obj)
+    ext = os.path.splitext(file_path)[1].lower()
+
+    temp_dir = None
+    audio_path = file_path
+
+    if ext == ".mp4":
+        temp_dir = tempfile.mkdtemp()
+        audio_path = os.path.join(temp_dir, "audio.wav")
+        with VideoFileClip(file_path) as video:
+            video.audio.write_audiofile(audio_path, verbose=False, logger=None)
+
+    segments, _ = model.transcribe(audio_path)
+    text = "".join(segment.text for segment in segments)
+
+    if temp_dir:
+        shutil.rmtree(temp_dir)
+
+    return text
+
+
+def main():
+    interface = gr.Interface(
+        fn=transcribe,
+        inputs=gr.File(label="Audio or Video (.mp3, .wav, .mp4)", type="file"),
+        outputs=gr.Textbox(label="Transcription"),
+        title="faster-whisper Transcription",
+    )
+    interface.launch()
+
+
+if __name__ == "__main__":
+    main()

--- a/run_app.bat
+++ b/run_app.bat
@@ -1,0 +1,9 @@
+@echo off
+IF NOT EXIST venv (
+    python -m venv venv
+)
+CALL venv\Scripts\activate
+pip install --upgrade pip
+pip install gradio moviepy
+pip install -e .
+python gradio_app.py


### PR DESCRIPTION
## Summary
- add a simple Gradio demo using `faster_whisper`
- include Windows batch script to set up a venv and run the demo

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'faster_whisper')*

------
https://chatgpt.com/codex/tasks/task_e_685b494e4220832bb513c1d43c87b34e