### PR TITLE
Add missing GUI dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,19 @@ logging.getLogger("faster_whisper").setLevel(logging.DEBUG)
 
 See more model and transcription options in the [`WhisperModel`](https://github.com/SYSTRAN/faster-whisper/blob/master/faster_whisper/transcribe.py) class implementation.
 
+### Gradio interface
+
+A minimal demo application is provided in `gradio_app.py`. After installing
+the package dependencies run:
+
+```bash
+pip install -r requirements.txt
+python gradio_app.py
+```
+
+This launches a web interface that accepts audio or video files and displays the
+transcription.
+
 ## Community integrations
 
 Here is a non exhaustive list of open-source projects using faster-whisper. Feel free to add your project to the list!

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 ctranslate2>=4.0,<5
 huggingface_hub>=0.13
 tokenizers>=0.13,<1
-onnxruntime>=1.14,<2 
+onnxruntime>=1.14,<2
 av>=11
+moviepy>=1.0
+gradio>=3.0
 tqdm


### PR DESCRIPTION
## Summary
- add `moviepy` and `gradio` to default requirements
- document how to run the Gradio demo app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b58545528832b8ac101de690f8d08