### PR TITLE
Switch to ffmpeg for video audio extraction

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ huggingface_hub>=0.13
 tokenizers>=0.13,<1
 onnxruntime>=1.14,<2
 av>=11
-moviepy>=1.0
+imageio-ffmpeg>=0.6
 gradio>=3.0
 tqdm

--- a/run_app.bat
+++ b/run_app.bat
@@ -34,7 +34,7 @@ IF EXIST "requirements.conversion.txt" (
 )
 
 REM Instalar los módulos críticos directamente
-pip install gradio moviepy || goto end
+pip install gradio imageio-ffmpeg || goto end
 pip install -e . || goto end
 
 REM Lanzar la app


### PR DESCRIPTION
## Summary
- avoid requiring `moviepy` by using `imageio-ffmpeg` for audio extraction in `gradio_app.py`
- update dependencies
- adjust Windows helper script accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b5cc79e8c832bb461e4b4fb68ceb5