### PR TITLE
Fix gradio file input type

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -50,7 +50,7 @@ def transcribe(file_obj):
 def main():
     interface = gr.Interface(
         fn=transcribe,
-        inputs=gr.File(label="Audio or Video (.mp3, .wav, .mp4)", type="file"),
+        inputs=gr.File(label="Audio or Video (.mp3, .wav, .mp4)", type="filepath"),
         outputs=gr.Textbox(label="Transcription"),
         title="faster-whisper Transcription",
     )


### PR DESCRIPTION
## Summary
- fix invalid type in gr.File so it returns filepath

## Testing
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_685b61d52b0c832ba15988264f8661ad